### PR TITLE
fix: upgrade Next.js to 15.5.14 (security patch)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "framer-motion": "^11.17.0",
     "gsap": "^3.13.0",
     "lucide-react": "^0.471.1",
-    "next": "^15.2.0",
+    "next": "^15.5.14",
     "next-international": "^1.3.1",
     "next-themes": "^0.4.4",
     "react": "^19.0.0",
@@ -37,7 +37,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "15.1.4",
+    "eslint-config-next": "15.5.14",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"


### PR DESCRIPTION
## Security Fix

Patch vulnerable version of Next.js (CVE). Update from 15.2.0 to 15.5.14.

### Changes
- Update `next` from `^15.2.0` to `^15.5.14`
- Update `eslint-config-next` from `15.1.4` to `15.5.14`

This fixes the detected vulnerability in Next.js 15.2.0.