### PR TITLE
fix: mobile nav menu z-index stacking issue on scroll

### DIFF
--- a/src/app/components/nav.tsx
+++ b/src/app/components/nav.tsx
@@ -101,57 +101,58 @@ const Header = () => {
           {isOpen ? <X size={24} /> : <Menu size={24} />}
         </button>
 
-        {/* Mobile Nav Overlay */}
-        <AnimatePresence>
-          {isOpen && (
-            <motion.div
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              className="fixed inset-0 bg-white z-40 flex flex-col justify-center items-center md:hidden"
-            >
-              <nav className="flex flex-col items-center gap-8 mb-12">
-                {navItems.map((item) => (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    className="text-3xl font-bold text-black tracking-tight"
-                    onClick={() => setIsOpen(false)}
-                  >
-                    {item.label}
-                  </Link>
-                ))}
-              </nav>
-
-              <div className="flex gap-6 text-lg font-medium">
-                <button
-                  onClick={() => {
-                    changeLocale("en");
-                    setIsOpen(false);
-                  }}
-                  className={`${
-                    locale === "en" ? "text-black" : "text-gray-400"
-                  }`}
-                >
-                  EN
-                </button>
-                <button
-                  onClick={() => {
-                    changeLocale("fr");
-                    setIsOpen(false);
-                  }}
-                  className={`${
-                    locale === "fr" ? "text-black" : "text-gray-400"
-                  }`}
-                >
-                  FR
-                </button>
-              </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
       </div>
     </header>
+
+    {/* Mobile Nav Overlay — outside header so z-index works correctly */}
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 bg-white z-[60] flex flex-col justify-center items-center md:hidden"
+        >
+          <nav className="flex flex-col items-center gap-8 mb-12">
+            {navItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className="text-3xl font-bold text-black tracking-tight"
+                onClick={() => setIsOpen(false)}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+
+          <div className="flex gap-6 text-lg font-medium">
+            <button
+              onClick={() => {
+                changeLocale("en");
+                setIsOpen(false);
+              }}
+              className={`${
+                locale === "en" ? "text-black" : "text-gray-400"
+              }`}
+            >
+              EN
+            </button>
+            <button
+              onClick={() => {
+                changeLocale("fr");
+                setIsOpen(false);
+              }}
+              className={`${
+                locale === "fr" ? "text-black" : "text-gray-400"
+              }`}
+            >
+              FR
+            </button>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 };
 


### PR DESCRIPTION
## Bug Fix

When scrolling down on mobile and then opening the hamburger menu, the menu was stuck behind the header and not visible.

### Root Cause
The mobile menu overlay was inside the `<header>` element with `z-40`, while the header had `z-50`. After scrolling (when header gets a white/blur background), the header visually covered the menu content.

### Fix
- Move the `AnimatePresence` mobile menu outside the `<header>` tag (now a sibling at root level)
- Raise z-index from `z-40` to `z-[60]` to ensure it always sits above the header

### Reproduction
1. Open site on mobile
2. Scroll down a bit
3. Click hamburger menu
4. Before: menu invisible/blocked by header
5. After: menu displays correctly